### PR TITLE
chore: refactor get_files and finding manifest

### DIFF
--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -5,8 +5,9 @@ import subprocess
 
 from publisher.release import (
     main,
+    get_files,
     get_private_token,
-    find_study_url,
+    find_manifest,
 )
 
 # Fixtures for these tests:
@@ -19,7 +20,7 @@ from publisher.release import (
 
 def test_successful_push_message(capsys, release_repo, study_repo):
     os.chdir(release_repo.name)
-    main(study_repo_url=study_repo.name, token="")
+    main(study_repo_url=study_repo.name, token="", files=get_files())
     captured = capsys.readouterr()
 
     assert captured.out.startswith("Pushed new changes")
@@ -27,7 +28,7 @@ def test_successful_push_message(capsys, release_repo, study_repo):
 
 def test_release_repo_master_branch_unchanged(release_repo, study_repo):
     os.chdir(release_repo.name)
-    main(study_repo_url=study_repo.name, token="")
+    main(study_repo_url=study_repo.name, token="", files=get_files())
     os.chdir(study_repo.name)
     committed = pathlib.Path("released_outputs/a/b/committed.txt")
     staged = pathlib.Path("released_outputs/a/b/staged.txt")
@@ -39,7 +40,7 @@ def test_release_repo_master_branch_unchanged(release_repo, study_repo):
 
 def test_release_repo_release_branch_changed(release_repo, study_repo):
     os.chdir(release_repo.name)
-    main(study_repo_url=study_repo.name, token="")
+    main(study_repo_url=study_repo.name, token="", files=get_files())
     os.chdir(study_repo.name)
     subprocess.check_output(["git", "checkout", "release-candidates"])
 
@@ -54,7 +55,7 @@ def test_release_repo_release_branch_changed(release_repo, study_repo):
 
 def test_release_repo_commit_history(release_repo, study_repo):
     os.chdir(release_repo.name)
-    main(study_repo_url=study_repo.name, token="")
+    main(study_repo_url=study_repo.name, token="", files=get_files())
     os.chdir(study_repo.name)
     log = subprocess.check_output(["git", "log", "--all"], encoding="utf8")
     assert "second commit" in log
@@ -68,8 +69,8 @@ def test_release_repo_commit_history(release_repo, study_repo):
 
 def test_noop_message(capsys, release_repo, study_repo):
     os.chdir(release_repo.name)
-    main(study_repo_url=study_repo.name, token="")
-    main(study_repo_url=study_repo.name, token="")
+    main(study_repo_url=study_repo.name, token="", files=get_files())
+    main(study_repo_url=study_repo.name, token="", files=get_files())
     captured = capsys.readouterr()
     assert captured.out.splitlines()[-1] == "Nothing to do!"
 
@@ -92,16 +93,16 @@ def test_get_private_token(tmp_path):
     )
 
 
-def test_find_study_url(tmp_path):
+def test_find_manifest(tmp_path):
     manifest_path = tmp_path / "metadata" / "manifest.json"
     manifest_path.parent.mkdir()
     manifest_path.write_text(json.dumps({"repo": "url"}))
     workdir = tmp_path / 'release'
     workdir.mkdir()
-    assert find_study_url(workdir) == "url"
+    assert find_manifest(workdir) == {"repo": "url"}
 
 
-def test_find_study_url_not_found(tmp_path):
+def test_find_manifest_not_found(tmp_path):
     workdir = tmp_path / 'release'
     workdir.mkdir()
-    assert find_study_url(workdir) is None
+    assert find_manifest(workdir) is None


### PR DESCRIPTION
 - make get_files() just return paths, and be explicit about the src
   directory.
 - make find_manifest logic more general
 
This is in preparation for adding the new release method