### PR TITLE
Send Notifications to Job Server

### DIFF
--- a/publisher/notify.py
+++ b/publisher/notify.py
@@ -1,0 +1,41 @@
+import json
+import os
+import urllib.error
+from urllib.request import Request, urlopen
+
+JOB_SERVER = os.environ.get("JOB_SERVER", "https://jobs.opensafely.org")
+
+
+def main(username, token, path):
+    data = json.dumps({"created_by": username, "path": path}).encode("utf-8")
+
+    request = Request(
+        url=f"{JOB_SERVER}/api/v2/release-notifications/",
+        data=data,
+        method="POST",
+        headers={
+            "Accept": "application/json",  # only for errors format
+            "Authorization": token,
+            "Content-Type": "application/json",
+        },
+    )
+
+    try:
+        response = urlopen(request)
+    except urllib.error.HTTPError as exc:
+        # HTTPErrors can be treated as HTTPResponse
+        response = exc
+
+    if response.status == 201:
+        print("Notification sent")
+        return
+
+    error_msg = response.read().decode("utf8")
+
+    # try get more helpful error message
+    if response.headers["Content-Type"] == "application/json":
+        try:
+            error_msg = json.loads(error_msg)["detail"]
+        except Exception:
+            pass
+    raise Exception(f"Error: {response.status} response from the server: {error_msg}")

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,49 @@
+import json
+import os
+from http import HTTPStatus
+
+import pytest
+
+import publisher
+from publisher.notify import main
+
+from .utils import UrlopenFixture
+
+
+@pytest.fixture
+def urlopen(monkeypatch):
+    data = UrlopenFixture()
+    monkeypatch.setattr(publisher.notify, "urlopen", data.urlopen)
+    return data
+
+
+def test_main_success(urlopen):
+    urlopen.set_response(
+        HTTPStatus.CREATED,
+        headers={
+            "Location": "/location",
+        },
+    )
+
+    main("testuser", "token", "/path/to/outputs")
+
+    JOB_SERVER = os.environ.get("JOB_SERVER", "https://jobs.opensafely.org")
+    assert urlopen.request.full_url == (f"{JOB_SERVER}/api/v2/release-notifications/")
+    assert urlopen.request.headers["Authorization"] == "token"
+    assert (
+        urlopen.request.data
+        == b'{"created_by": "testuser", "path": "/path/to/outputs"}'
+    )
+
+
+def test_main_error_response(urlopen):
+    urlopen.set_response(
+        HTTPStatus.BAD_REQUEST,
+        headers={"Content-Type": "application/json"},
+        body=json.dumps({"detail": "ERROR MSG"}),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        main("testuser", "token", "/path/to/outputs")
+
+    assert str(exc_info.value) == "Error: 400 response from the server: ERROR MSG"

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -121,8 +121,9 @@ def test_main_success(release_dir, release_files, urlopen, capsys):
 
     main(release_dir, release_files, manifest, "token")
 
+    JOB_SERVER = os.environ.get("JOB_SERVER", "https://jobs.opensafely.org")
     assert urlopen.request.full_url == (
-        f"https://jobs.opensafely.org/api/v2/workspaces/workspace/releases/{release_hash}"
+        f"{JOB_SERVER}/api/v2/workspaces/workspace/releases/{release_hash}"
     )
     assert urlopen.request.headers["Authorization"] == "token"
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,45 @@
+import io
+from datetime import datetime
+from http.client import HTTPResponse
+
+
+class UrlopenFixture:
+    """Fixture for mocking urlopen."""
+
+    request = None
+    response = None
+
+    class socket:
+        """Minimal socket api as used by HTTPResponse"""
+
+        def __init__(self, data):
+            self.stream = io.BytesIO(data)
+
+        def makefile(self, mode):
+            return self.stream
+
+    def set_response(self, status, headers={}, body=None):
+        """Create a HTTP response byte-stream to be parsed by HTTPResponse."""
+        lines = [f"HTTP/1.1 {status.value} {status.phrase}"]
+        lines.append(f"Date: {datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S')}")
+        lines.append("Server: TestServer/1.0")
+        for name, value in headers.items():
+            lines.append(f"{name}: {value}")
+
+        if body:
+            lines.append(f"Content-Length: {len(body)}")
+            lines.append("")
+            lines.append("")
+
+        data = ("\r\n".join(lines)).encode("ascii")
+        if body:
+            data += body.encode("utf8")
+
+        self.sock = self.socket(data)
+
+    def urlopen(self, request):
+        """Replacement urlopen function."""
+        self.request = request
+        self.response = HTTPResponse(self.sock, method=request.method)
+        self.response.begin()
+        return self.response


### PR DESCRIPTION
This adds a notification step to the end of the release script, uploading the current username and the path from which the files were released to the job-server.

Related PR: opensafely-core/job-server#515