### PR TITLE
fix: unwrap path when notifying job-server

### DIFF
--- a/publisher/release.py
+++ b/publisher/release.py
@@ -251,7 +251,7 @@ def run():
 
     # notify job-server that outputs have been released
     try:
-        notify.main(username, backend_token, Path(os.getcwd()))
+        notify.main(username, backend_token, os.getcwd())
     except Exception as exc:
         if options.verbose > 0:
             raise


### PR DESCRIPTION
Forgot to check this in previously so my local testing worked 🤦‍♂️