### PR TITLE
Support setting files on cli

### DIFF
--- a/publisher/upload.py
+++ b/publisher/upload.py
@@ -24,11 +24,10 @@ def hash_files(release_dir, files):
 JOB_SERVER = os.environ.get("JOB_SERVER", "https://jobs.opensafely.org")
 
 
-def main(release_dir, files, manifest, token):
+def main(release_dir, files, workspace, token):
     # include the manifest in the release
     files.append(Path("metadata/manifest.json"))
     release_hash = hash_files(release_dir, files)
-    workspace = manifest["workspace"]
 
     zip_buffer = io.BytesIO()
     with ZipFile(zip_buffer, "w") as zip_file:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ import tempfile
 
 import pytest
 
+from publisher import release
+
 
 def git_init():
     subprocess.check_call(["git", "init"])
@@ -58,3 +60,8 @@ def study_repo():
     os.chdir(d.name)
     git_init()
     return d
+
+
+@pytest.fixture
+def options():
+    return release.parser.parse_args([])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,48 +1,198 @@
-import json
+import getpass
 import os
-import pathlib
-import subprocess
 import sys
+from pathlib import Path
 
-import publisher.config
-from publisher.config import get_config, get_config_value
+import pytest
+
+from publisher import config
+from tests.test_upload import write_manifest
+
+
+def write_config(tmp_path, **kwargs):
+    lines = []
+    for name, value in kwargs.items():
+        lines.append(f"{name} = {repr(value)}")
+    cfg = tmp_path / "osrelease_config.py"
+    cfg.write_text("\n".join(lines))
+    print("\n".join(lines))
+    return {"OSRELEASE_CONFIG": str(cfg)}
+
+
+@pytest.fixture
+def default_config(tmp_path, monkeypatch):
+    env = write_config(
+        tmp_path,
+        BACKEND_TOKEN="token",
+        PRIVATE_REPO_ACCESS_TOKEN="private",
+        ALLOWED_USERS=[getpass.getuser()],
+    )
+    monkeypatch.setitem(os.environ, "OSRELEASE_CONFIG", env["OSRELEASE_CONFIG"])
 
 
 def test_config_osrelease_config_env_var(tmp_path):
-    config = tmp_path / "osrelease_config.py"
-    config.write_text("FOO=1")
-    env = {"OSRELEASE_CONFIG": str(config)}
-    assert get_config(env) == {"FOO": 1}
+    cfg = tmp_path / "osrelease_config.py"
+    cfg.write_text("FOO=1")
+    env = {"OSRELEASE_CONFIG": str(cfg)}
+    assert config.get_config(env) == {"FOO": 1}
 
 
 def test_config_file_cwd(tmp_path):
-    config = tmp_path / "osrelease_config.py"
-    config.write_text("FOO=1")
+    cfg = tmp_path / "osrelease_config.py"
+    cfg.write_text("FOO=1")
     current = os.getcwd()
     try:
         os.chdir(tmp_path)
-        assert get_config({}) == {"FOO": 1}
+        assert config.get_config({}) == {"FOO": 1}
     finally:
         os.chdir(current)
 
 
 def test_config_file_venv(tmp_path):
-    config = tmp_path / "osrelease_config.py"
-    config.write_text("FOO=1")
+    cfg = tmp_path / "osrelease_config.py"
+    cfg.write_text("FOO=1")
     env = {"VIRTUAL_ENV": str(tmp_path)}
-    assert get_config(env) == {"FOO": 1}
+    assert config.get_config(env) == {"FOO": 1}
 
 
 def test_config_file_module(tmp_path, monkeypatch):
-    config = tmp_path / "osrelease_config.py"
+    cfg = tmp_path / "osrelease_config.py"
     executable = tmp_path / "bin" / "python"
     monkeypatch.setattr(sys, "executable", str(executable))
-    config.write_text("FOO=1")
-    assert get_config({}) == {"FOO": 1}
+    cfg.write_text("FOO=1")
+    assert config.get_config({}) == {"FOO": 1}
 
 
-def test_get_config_value(tmp_path):
-    config = tmp_path / "osrelease_config.py"
-    config.write_text("PRIVATE_REPO_ACCESS_TOKEN='token'")
-    env = {"OSRELEASE_CONFIG": str(config)}
-    assert get_config_value("PRIVATE_REPO_ACCESS_TOKEN", env) == "token"
+def test_get_current_user(monkeypatch):
+    real_user = getpass.getuser()
+
+    monkeypatch.setattr("publisher.config.getpass.getuser", lambda: "user")
+    assert config.get_current_user() == "user"
+
+    if "GITHUB_ACTIONS" not in os.environ:
+        monkeypatch.setattr("publisher.config.getpass.getuser", lambda: "jobrunner")
+        assert config.get_current_user() == real_user
+
+
+def test_load_config_files_not_exist(options, tmp_path):
+    write_manifest(tmp_path)
+    options.files = ["notexist"]
+
+    with pytest.raises(SystemExit) as exc_info:
+        config.load_config(options, tmp_path)
+
+    assert "Files do not exist: notexist" in str(exc_info.value)
+
+
+def test_load_config_files_no_backend_token(options, tmp_path):
+    write_manifest(tmp_path)
+
+    with pytest.raises(SystemExit) as exc_info:
+        config.load_config(options, tmp_path)
+
+    assert "Could not load BACKEND_TOKEN" in str(exc_info.value)
+
+
+def test_load_config_new_publish_no_files(options, tmp_path):
+    write_manifest(tmp_path)
+    env = write_config(tmp_path, BACKEND_TOKEN="token")
+    options.new_publish = True
+
+    with pytest.raises(SystemExit) as exc_info:
+        config.load_config(options, tmp_path, env=env)
+
+    assert "No files provided to release" in str(exc_info.value)
+
+
+def test_load_config_old_publish_no_private_token(options, tmp_path):
+    write_manifest(tmp_path)
+    env = write_config(tmp_path, BACKEND_TOKEN="token")
+
+    with pytest.raises(SystemExit) as exc_info:
+        config.load_config(options, tmp_path, env=env)
+
+    assert "Could not load PRIVATE" in str(exc_info.value)
+
+
+def test_load_config_old_publish_no_git(options, tmp_path):
+    write_manifest(tmp_path)
+    env = write_config(
+        tmp_path, BACKEND_TOKEN="token", PRIVATE_REPO_ACCESS_TOKEN="private"
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        config.load_config(options, tmp_path, env=env)
+
+    assert "No files provided to release" in str(exc_info.value)
+
+
+def test_load_config_username_not_allowed(options, tmp_path, monkeypatch):
+    write_manifest(tmp_path)
+    env = write_config(
+        tmp_path, BACKEND_TOKEN="token", PRIVATE_REPO_ACCESS_TOKEN="private"
+    )
+    f = tmp_path / "file.txt"
+    f.write_text("test")
+    options.files = [str(f)]
+    monkeypatch.setattr("publisher.config.getpass.getuser", lambda: "user")
+
+    with pytest.raises(SystemExit) as exc_info:
+        config.load_config(options, tmp_path, env=env)
+
+    assert "Only members of the core OpenSAFELY team" in str(exc_info.value)
+
+
+def test_load_config_new_publish(options, tmp_path, default_config):
+    write_manifest(tmp_path)
+    f = tmp_path / "file.txt"
+    f.write_text("test")
+    options.files = [str(f)]
+    options.new_publish = True
+
+    files, cfg = config.load_config(options, tmp_path)
+    assert files == [f]
+    assert cfg == {
+        "backend_token": "token",
+        "private_token": "private",
+        "study_repo_url": "repo",
+        "workspace": "workspace",
+        "username": getpass.getuser(),
+    }
+
+
+def test_load_config_old_publish_with_files(options, tmp_path, default_config):
+    write_manifest(tmp_path)
+    f = tmp_path / "file.txt"
+    f.write_text("test")
+    options.files = [str(f)]
+
+    files, cfg = config.load_config(options, tmp_path)
+    assert files == [f]
+    assert cfg == {
+        "backend_token": "token",
+        "private_token": "private",
+        "study_repo_url": "repo",
+        "workspace": "workspace",
+        "username": getpass.getuser(),
+    }
+
+
+def test_load_config_old_publish_with_git(
+    options, tmp_path, default_config, release_repo
+):
+    os.chdir(release_repo.name)
+    rpath = Path(release_repo.name)
+
+    write_manifest(rpath)
+    f = tmp_path / "file.txt"
+    f.write_text("test")
+
+    files, cfg = config.load_config(options, rpath)
+    assert files == [Path("a/b/committed.txt")]
+    assert cfg == {
+        "backend_token": "token",
+        "private_token": "private",
+        "study_repo_url": "repo",
+        "workspace": "workspace",
+        "username": getpass.getuser(),
+    }

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -30,7 +30,6 @@ def release_files(release_dir):
         "outputs/data.csv": "data",
     }
 
-    filepaths = []
     for name, contents in files.items():
         path = release_dir / name
         path.parent.mkdir(exist_ok=True, parents=True)
@@ -71,11 +70,11 @@ def test_main_success(release_dir, release_files, urlopen, capsys):
             "Location": "/location",
         },
     )
-    manifest = write_manifest(release_dir, workspace="workspace")
+    write_manifest(release_dir, workspace="workspace")
     # the hash for these test files + manifest contents
     release_hash = "d30535e1a8f6d000f1ed1a58ba5b9af1"
 
-    main(release_dir, release_files, manifest, "token")
+    main(release_dir, release_files, "workspace", "token")
 
     JOB_SERVER = os.environ.get("JOB_SERVER", "https://jobs.opensafely.org")
     assert urlopen.request.full_url == (
@@ -99,9 +98,9 @@ def test_main_redirect(release_dir, release_files, urlopen, capsys):
             "Location": "/location",
         },
     )
-    manifest = write_manifest(release_dir, workspace="workspace")
+    write_manifest(release_dir, workspace="workspace")
 
-    main(release_dir, release_files, manifest, "token")
+    main(release_dir, release_files, "workspace", "token")
 
     out, err = capsys.readouterr()
     assert out == "Release already uploaded at /location\n"


### PR DESCRIPTION
Using a local git dir is still supported but is now deprecated.

Instead just pass the files on the cli you want to release.

In addition, the validation logic was intertwined with run() and not
tested, so I pulled the parsing/validation of config and cli args into
the `config` module, and make it separately testable.