### PR TITLE
Hardcode the commit message.

### DIFF
--- a/publisher/config.py
+++ b/publisher/config.py
@@ -132,13 +132,15 @@ def load_config(options, release_dir, env=os.environ):
             "Only members of the core OpenSAFELY team can publish outputs. "
             "Please email disclosurecontrol@opensafely.org to request a release.\n"
         )
+    username = allowed_usernames[local_username]
 
     config = {
         "backend_token": cfg.get("BACKEND_TOKEN"),
         "private_token": cfg.get("PRIVATE_REPO_ACCESS_TOKEN"),
         "study_repo_url": manifest["repo"],
         "workspace": manifest["workspace"],
-        "username": allowed_usernames[local_username],
+        "username": username,
+        "commit_message": f"Released from {release_dir} by {username}",
     }
 
     if not config["backend_token"]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -187,6 +187,7 @@ def test_load_config_new_publish(options, tmp_path, default_config):
         "study_repo_url": "repo",
         "workspace": "workspace",
         "username": "github-user",
+        "commit_message": f"Released from {tmp_path} by github-user",
     }
 
 
@@ -209,6 +210,7 @@ def test_load_config_new_publish_dirs(options, tmp_path, default_config):
         "study_repo_url": "repo",
         "workspace": "workspace",
         "username": "github-user",
+        "commit_message": f"Released from {tmp_path} by github-user",
     }
 
 
@@ -226,6 +228,7 @@ def test_load_config_old_publish_with_files(options, tmp_path, default_config):
         "study_repo_url": "repo",
         "workspace": "workspace",
         "username": "github-user",
+        "commit_message": f"Released from {tmp_path} by github-user",
     }
 
 
@@ -247,4 +250,5 @@ def test_load_config_old_publish_with_git(
         "study_repo_url": "repo",
         "workspace": "workspace",
         "username": "github-user",
+        "commit_message": f"Released from {rpath} by github-user",
     }

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -18,7 +18,9 @@ from publisher import config, release
 def test_successful_push_message(capsys, release_repo, study_repo):
     os.chdir(release_repo.name)
     files = config.git_files(Path(release_repo.name))
-    release.main(study_repo_url=study_repo.name, token="", files=files)
+    release.main(
+        study_repo_url=study_repo.name, token="", files=files, commit_msg="msg"
+    )
     captured = capsys.readouterr()
 
     assert captured.out.startswith("Pushed new changes")
@@ -27,8 +29,10 @@ def test_successful_push_message(capsys, release_repo, study_repo):
 def test_release_repo_master_branch_unchanged(release_repo, study_repo):
     os.chdir(release_repo.name)
     files = config.git_files(Path(release_repo.name))
-    release.main(study_repo_url=study_repo.name, token="", files=files)
-    os.chdir(study_repo.name)
+    release.main(
+        study_repo_url=study_repo.name, token="", files=files, commit_msg="msg"
+    )
+    os.chdir(study_repo.name),
     committed = Path("released_outputs/a/b/committed.txt")
     staged = Path("released_outputs/a/b/staged.txt")
     unstaged = Path("released_outputs/a/b/unstaged.txt")
@@ -40,7 +44,9 @@ def test_release_repo_master_branch_unchanged(release_repo, study_repo):
 def test_release_repo_release_branch_changed(release_repo, study_repo):
     os.chdir(release_repo.name)
     files = config.git_files(Path(release_repo.name))
-    release.main(study_repo_url=study_repo.name, token="", files=files)
+    release.main(
+        study_repo_url=study_repo.name, token="", files=files, commit_msg="msg"
+    )
     os.chdir(study_repo.name)
     subprocess.check_output(["git", "checkout", "release-candidates"])
 
@@ -53,26 +59,15 @@ def test_release_repo_release_branch_changed(release_repo, study_repo):
     assert not unstaged.exists()
 
 
-def test_release_repo_commit_history(release_repo, study_repo):
-    os.chdir(release_repo.name)
-    files = config.git_files(Path(release_repo.name))
-    release.main(study_repo_url=study_repo.name, token="", files=files)
-    os.chdir(study_repo.name)
-    log = subprocess.check_output(["git", "log", "--all"], encoding="utf8")
-    assert "second commit" in log
-    assert "first commit" not in log
-
-    search = subprocess.check_output(
-        ["git", "log", "--all", "-Sunredacted"], encoding="utf8"
-    )
-    assert search == ""
-
-
 def test_noop_message(capsys, release_repo, study_repo):
     os.chdir(release_repo.name)
     files = config.git_files(Path(release_repo.name))
-    release.main(study_repo_url=study_repo.name, token="", files=files)
-    release.main(study_repo_url=study_repo.name, token="", files=files)
+    release.main(
+        study_repo_url=study_repo.name, token="", files=files, commit_msg="msg"
+    )
+    release.main(
+        study_repo_url=study_repo.name, token="", files=files, commit_msg="msg"
+    )
     captured = capsys.readouterr()
     assert captured.out.splitlines()[-1] == "Nothing to do!"
 


### PR DESCRIPTION
This allows us to contol the commit message to give more info. Also
fixes a but when specifiying files on the command line but still
releasing via git.
