### PR TITLE
Release choice

### DIFF
--- a/publisher/config.py
+++ b/publisher/config.py
@@ -12,7 +12,6 @@ def check_workplace_status(workspace_name):
     res = requests.get(
         f"https://jobs.opensafely.org/api/v2/workspaces/{workspace_name}/status"
     )
-    uses_new_workflow = res.json()
     if res.status_code == 500:
         sys.exit(f"Error: {res.status_code} response from {res.url}: Job Server down")
     elif res.status_code != 200:
@@ -20,7 +19,7 @@ def check_workplace_status(workspace_name):
             f"Error: {res.status_code} response from {res.url}: {res.json()['detail']}"
         )
     else:
-        return uses_new_workflow["uses_new_release_flow"]
+        return res.json()["uses_new_release_flow"]
 
 
 def get_config_file(env, filename="osrelease_config.py"):

--- a/publisher/release.py
+++ b/publisher/release.py
@@ -10,6 +10,8 @@ import tempfile
 import urllib.parse
 from pathlib import Path
 
+import requests
+
 from . import config, notify
 
 GITHUB_PROXY_DOMAIN = "github-proxy.opensafely.org"
@@ -168,7 +170,12 @@ def release(options, release_dir):
             ):
                 sys.exit()
 
-        if options.new_publish:
+        res = requests.get(
+            f"https://jobs.opensafely.org/api/v2/workspaces/{cfg['workspace']}/status"
+        )
+        uses_new_workflow = res.json()
+
+        if options.new_publish or uses_new_workflow["uses_new_release_flow"]:
             # defer loading temporarily as it has dependencies that are not in
             # place in prod
             from publisher import upload

--- a/publisher/release.py
+++ b/publisher/release.py
@@ -157,6 +157,14 @@ def main(study_repo_url, token, files, commit_msg):
         return released
 
 
+def check_status(workspace_name):
+    res = requests.get(
+        f"https://jobs.opensafely.org/api/v2/workspaces/{workspace_name}/status"
+    )
+    uses_new_workflow = res.json()
+    return uses_new_workflow["uses_new_release_flow"]
+
+
 def release(options, release_dir):
     try:
         files, cfg = config.load_config(options, release_dir)
@@ -170,12 +178,9 @@ def release(options, release_dir):
             ):
                 sys.exit()
 
-        res = requests.get(
-            f"https://jobs.opensafely.org/api/v2/workspaces/{cfg['workspace']}/status"
-        )
-        uses_new_workflow = res.json()
+        use_new_workflow = check_status(cfg["workspace"])
 
-        if options.new_publish or uses_new_workflow["uses_new_release_flow"]:
+        if options.new_publish or use_new_workflow:
             # defer loading temporarily as it has dependencies that are not in
             # place in prod
             from publisher import upload

--- a/publisher/release.py
+++ b/publisher/release.py
@@ -10,8 +10,6 @@ import tempfile
 import urllib.parse
 from pathlib import Path
 
-import requests
-
 from . import config, notify
 
 GITHUB_PROXY_DOMAIN = "github-proxy.opensafely.org"
@@ -157,15 +155,6 @@ def main(study_repo_url, token, files, commit_msg):
         return released
 
 
-def check_status(workspace_name):
-    res = requests.get(
-        f"https://jobs.opensafely.org/api/v2/workspaces/{workspace_name}/status"
-    )
-    uses_new_workflow = res.json()
-    res.raise_for_status()
-    return bool(uses_new_workflow["uses_new_release_flow"])
-
-
 def release(options, release_dir):
     try:
         files, cfg = config.load_config(options, release_dir)
@@ -179,9 +168,7 @@ def release(options, release_dir):
             ):
                 sys.exit()
 
-        use_new_workflow = check_status(cfg["workspace"])
-
-        if options.new_publish or use_new_workflow:
+        if options.new_publish:
             # defer loading temporarily as it has dependencies that are not in
             # place in prod
             from publisher import upload

--- a/publisher/release.py
+++ b/publisher/release.py
@@ -162,7 +162,8 @@ def check_status(workspace_name):
         f"https://jobs.opensafely.org/api/v2/workspaces/{workspace_name}/status"
     )
     uses_new_workflow = res.json()
-    return uses_new_workflow["uses_new_release_flow"]
+    res.raise_for_status()
+    return bool(uses_new_workflow["uses_new_release_flow"])
 
 
 def release(options, release_dir):

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -6,3 +6,4 @@ flake8
 isort
 pre-commit
 pytest
+responses

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -73,10 +73,15 @@ pyyaml==5.3.1
 regex==2020.10.15
     # via black
 requests==2.26.0
-    # via -r requirements.prod.txt
+    # via
+    #   -r requirements.prod.txt
+    #   responses
+responses==0.14.0
+    # via -r requirements.dev.in
 six==1.15.0
     # via
     #   packaging
+    #   responses
     #   virtualenv
 toml==0.10.1
     # via
@@ -94,5 +99,6 @@ urllib3==1.26.7
     # via
     #   -r requirements.prod.txt
     #   requests
+    #   responses
 virtualenv==20.0.35
     # via pre-commit

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -12,8 +12,16 @@ attrs==20.2.0
     # via pytest
 black==20.8b1
     # via -r requirements.dev.in
+certifi==2021.5.30
+    # via
+    #   -r requirements.prod.txt
+    #   requests
 cfgv==3.2.0
     # via pre-commit
+charset-normalizer==2.0.6
+    # via
+    #   -r requirements.prod.txt
+    #   requests
 click==7.1.2
     # via black
 distlib==0.3.1
@@ -24,6 +32,10 @@ flake8==3.8.4
     # via -r requirements.dev.in
 identify==1.5.6
     # via pre-commit
+idna==3.2
+    # via
+    #   -r requirements.prod.txt
+    #   requests
 iniconfig==1.1.1
     # via pytest
 isort==5.6.4
@@ -60,6 +72,8 @@ pyyaml==5.3.1
     # via pre-commit
 regex==2020.10.15
     # via black
+requests==2.26.0
+    # via -r requirements.prod.txt
 six==1.15.0
     # via
     #   packaging
@@ -76,5 +90,9 @@ typing-extensions==3.10.0.0
     #   -r requirements.prod.txt
     #   black
     #   pydantic
+urllib3==1.26.7
+    # via
+    #   -r requirements.prod.txt
+    #   requests
 virtualenv==20.0.35
     # via pre-commit

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -1,2 +1,3 @@
 itsdangerous
 pydantic
+requests

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -4,9 +4,19 @@
 #
 #    pip-compile requirements.prod.in
 #
+certifi==2021.5.30
+    # via requests
+charset-normalizer==2.0.6
+    # via requests
+idna==3.2
+    # via requests
 itsdangerous==2.0.1
     # via -r requirements.prod.in
 pydantic==1.8.2
     # via -r requirements.prod.in
+requests==2.26.0
+    # via -r requirements.prod.in
 typing-extensions==3.10.0.0
     # via pydantic
+urllib3==1.26.7
+    # via requests

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -6,8 +6,7 @@ from pathlib import Path
 import pytest
 
 
-from publisher import config, release, upload
-from .utils import UrlopenFixture
+from publisher import config, release
 
 # Fixtures for these tests:
 #
@@ -15,13 +14,6 @@ from .utils import UrlopenFixture
 # staged file, and one unstaged file
 #
 # a `study_repo` is an empty git repo
-
-
-@pytest.fixture
-def urlopen(monkeypatch):
-    data = UrlopenFixture()
-    monkeypatch.setattr(upload, "urlopen", data.urlopen)
-    return data
 
 
 def test_successful_push_message(capsys, release_repo, study_repo):


### PR DESCRIPTION
## Background
We currently have two methods to release outputs to the outside world. 
1. Via Github
2. Via Output Publisher

At present we use the `-n` or `--new-publish` CLI flag to decide whether to do the new one or the old one. 
It would be better if this used a direct API call to the workspace status to decide which method should be used. 

## Implementation
This uses `requests` library to make a GET call to return the boolean value for `uses_new_release_flow`. There is then a OR statement added to the line that checks if `-n` has been passed in. This is to ensure that the CLI option still exists. 

## Testing
There are no tests for this at present but this is something we should add.