### PR TITLE
Support central debugging log

### DIFF
--- a/publisher/config.py
+++ b/publisher/config.py
@@ -1,11 +1,14 @@
 import getpass
 import json
+import logging
 import os
 import subprocess
 import sys
 from pathlib import Path
 
 import requests
+
+logger = logging.getLogger(__name__)
 
 
 def check_workplace_status(workspace_name):
@@ -108,7 +111,7 @@ def ensure_git_config():
         subprocess.check_output(["git", "config", "--global", "user.name"])
         subprocess.check_output(["git", "config", "--global", "user.email"])
     except subprocess.CalledProcessError:
-        print(
+        logger.info(
             "You need to tell git who you are by running:\n\n"
             'git config --global user.name "YOUR NAME"\n'
             'git config --global user.email "YOUR EMAIL"'
@@ -187,7 +190,7 @@ def load_config(options, release_dir, env=os.environ):
 
         if not files:
             if Path(".git").exists():
-                print("Found git repo, using deprecated git release flow.")
+                logger.info("Found git repo, using deprecated git release flow.")
                 files = git_files(release_dir)
             else:
                 sys.exit("No files provided to release")

--- a/publisher/notify.py
+++ b/publisher/notify.py
@@ -1,7 +1,10 @@
 import json
+import logging
 import os
 import urllib.error
 from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
 
 JOB_SERVER = os.environ.get("JOB_SERVER", "https://jobs.opensafely.org")
 
@@ -33,7 +36,7 @@ def main(token, username, path, files):
         response = exc
 
     if response.status == 201:
-        print("Notification sent")
+        logging.info("Notification sent")
         return
 
     error_msg = response.read().decode("utf8")

--- a/publisher/release.py
+++ b/publisher/release.py
@@ -24,6 +24,7 @@ logging_defaults = {
     "workspace": os.getcwd(),
 }
 
+
 def record_with_defaults(*args, **kwargs):
     record = logging.LogRecord(*args, **kwargs)
     record.__dict__.update(logging_defaults)
@@ -41,7 +42,7 @@ def configure_logging():
     user_output = RedactingStreamHandler()
     user_output.setLevel(logging.INFO)
     root.addHandler(user_output)
-    
+
     logfile = os.environ.get("LOGFILE")
     if logfile:
         # add user and workspace dir to LogRecords
@@ -50,7 +51,7 @@ def configure_logging():
         formatter = logging.Formatter(
             fmt="{asctime} '{message}' user={user} dir={workspace}",
             datefmt="%Y-%m-%d %H:%M:%S",
-            style='{',
+            style="{",
         )
         # use utc time
         formatter.convertor = time.gmtime

--- a/publisher/release.py
+++ b/publisher/release.py
@@ -43,7 +43,8 @@ def configure_logging():
     user_output.setLevel(logging.INFO)
     root.addHandler(user_output)
 
-    logfile = os.environ.get("LOGFILE")
+    cfg = config.get_config(os.environ)
+    logfile = cfg.get("LOGFILE")
     if logfile:
         # add user and workspace dir to LogRecords
         logging.setLogRecordFactory(record_with_defaults)

--- a/publisher/release.py
+++ b/publisher/release.py
@@ -105,14 +105,6 @@ def run_cmd(cmd, raise_exc=True, output_failure=True):
     return result.returncode
 
 
-def tree(directory):
-    print(f"+ {directory}")
-    for path in sorted(directory.rglob("*")):
-        depth = len(path.relative_to(directory).parts)
-        spacer = "    " * depth
-        print(f"{spacer}+ {path.name}")
-
-
 def make_index(subdir):
     lines = []
     for path in sorted(Path(subdir).rglob("*")):
@@ -199,15 +191,15 @@ def main(study_repo_url, token, files, commit_msg, user, backend):
                             release_branch,
                         ]
                     )
-                    print(
+                    logger.info(
                         "Pushed new changes. Open a PR at "
                         f"`{study_repo_url.replace('.git', '')}/compare/{release_branch}`"
                     )
                     released = True
                 else:
-                    print("Nothing to do!")
+                    logger.info("Nothing to do!")
             else:
-                print("Local repo is empty!")
+                logger.info("Local repo is empty!")
         finally:
             # ensure we do not maintain an open handle on the temp dir, or else
             # the clean up fails
@@ -221,7 +213,7 @@ def release(options, release_dir):
         files, cfg = config.load_config(options, release_dir)
 
         if not options.yes:
-            print("\n".join(str(f) for f in files))
+            logger.info("\n".join(str(f) for f in files))
             print()
             if (
                 input("The above files will be published. Continue? (y/N)").lower()

--- a/publisher/signing.py
+++ b/publisher/signing.py
@@ -9,8 +9,7 @@ import hashlib
 from datetime import datetime, timezone
 
 import itsdangerous
-from pydantic import (BaseModel, Field, ValidationError, root_validator,
-                      validator)
+from pydantic import BaseModel, Field, ValidationError, root_validator, validator
 
 
 def create_signer(secret_key, salt):

--- a/publisher/upload.py
+++ b/publisher/upload.py
@@ -11,7 +11,6 @@ from urllib.request import Request, urlopen
 from publisher.schema import Release, ReleaseFile, UrlFileName
 from publisher.signing import AuthToken
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/publisher/upload.py
+++ b/publisher/upload.py
@@ -1,6 +1,7 @@
 import hashlib
 import io
 import json
+import logging
 import os
 import urllib.error
 from datetime import datetime, timedelta, timezone
@@ -9,6 +10,9 @@ from urllib.request import Request, urlopen
 
 from publisher.schema import Release, ReleaseFile, UrlFileName
 from publisher.signing import AuthToken
+
+
+logger = logging.getLogger(__name__)
 
 
 class UploadException(Exception):
@@ -40,23 +44,23 @@ def main(files, workspace, backend_token, user, api_server):
 
     release_id = response.headers["Release-Id"]
     release_url = response.headers["Location"]
-    print(f"Release {release_id} created with {len(files)} files.")
+    logger.info(f"Release {release_id} created with {len(files)} files.")
 
     try:
         for f in files:
             release_file = ReleaseFile(name=UrlFileName(f))
-            print(f" - uploading {f}... ", end="")
+            logger.info(f" - uploading {f}... ", end="")
             do_post(release_url, release_file.json(), auth_token)
-            print("done")
+            logger.info("done")
     except Forbidden:
         # they can create releases, but not upload them
-        print("permission denied")
-        print(
+        logger.info("permission denied")
+        logger.info(
             f"You do not have permission to upload the requested files for Release {release_id}.\n"
             f"The OpenSAFELY review team will review your requested Release."
         )
     else:
-        print(f"Uploaded {len(files)} files for Release {release_id}")
+        logger.info(f"Uploaded {len(files)} files for Release {release_id}")
 
 
 def get_token(url, user, backend_token):
@@ -69,7 +73,7 @@ def get_token(url, user, backend_token):
 
 
 def do_post(url, data, auth_token):
-
+    logger.debug(f"POST {url}: {data}")
     data = data.encode("utf8")
     request = Request(
         url=url,

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -109,7 +109,10 @@ def test_redacting_logger(capsys):
 
     _, err = capsys.readouterr()
 
-    assert err == "https://xxxxxx@github-proxy.opensafely.org\nhttps://xxxxxx@github-proxy.opensafely.org\n"
+    assert (
+        err
+        == "https://xxxxxx@github-proxy.opensafely.org\nhttps://xxxxxx@github-proxy.opensafely.org\n"
+    )
 
 
 def test_releaseno_args(tmp_path):

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -105,10 +105,11 @@ def test_redacting_logger(capsys):
     ch.setLevel(logging.DEBUG)
     logger.addHandler(ch)
     logger.info("https://token@github-proxy.opensafely.org")
+    logger.info("https://user:token@github-proxy.opensafely.org")
 
     _, err = capsys.readouterr()
 
-    assert err == "https://xxxxxx@github-proxy.opensafely.org\n"
+    assert err == "https://xxxxxx@github-proxy.opensafely.org\nhttps://xxxxxx@github-proxy.opensafely.org\n"
 
 
 def test_releaseno_args(tmp_path):

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -15,7 +15,8 @@ from publisher import config, release
 # a `study_repo` is an empty git repo
 
 
-def test_successful_push_message(capsys, release_repo, study_repo):
+def test_successful_push_message(caplog, release_repo, study_repo):
+    caplog.set_level(logging.INFO)
     os.chdir(release_repo.name)
     files = config.git_files(Path(release_repo.name))
     release.main(
@@ -26,9 +27,8 @@ def test_successful_push_message(capsys, release_repo, study_repo):
         user="user",
         backend="test",
     )
-    captured = capsys.readouterr()
 
-    assert captured.out.startswith("Pushed new changes")
+    assert caplog.records[-1].msg.startswith("Pushed new changes")
 
 
 def test_release_repo_master_branch_unchanged(release_repo, study_repo):
@@ -74,7 +74,8 @@ def test_release_repo_release_branch_changed(release_repo, study_repo):
     assert not unstaged.exists()
 
 
-def test_noop_message(capsys, release_repo, study_repo):
+def test_noop_message(caplog, release_repo, study_repo):
+    caplog.set_level(logging.INFO)
     os.chdir(release_repo.name)
     files = config.git_files(Path(release_repo.name))
     release.main(
@@ -93,8 +94,7 @@ def test_noop_message(capsys, release_repo, study_repo):
         user="user",
         backend="test",
     )
-    captured = capsys.readouterr()
-    assert captured.out.splitlines()[-1] == "Nothing to do!"
+    assert caplog.records[-1].msg == "Nothing to do!"
 
 
 def test_redacting_logger(capsys):


### PR DESCRIPTION
- Add a centralised log option
- convert remain print statements to logs
- blacken
- use config from file rather than environment, as that doesn't work on windows
- fix tests broken due to switch from print() to logger.info()
