### PR TITLE
Fix path separator handling.

### DIFF
--- a/publisher/schema.py
+++ b/publisher/schema.py
@@ -61,4 +61,4 @@ class ReleaseFile(BaseModel):
     bytes itself.
     """
 
-    name: str
+    name: UrlFileName

--- a/publisher/upload.py
+++ b/publisher/upload.py
@@ -30,7 +30,7 @@ def main(files, workspace, backend_token, user, api_server):
 
     release = Release(
         files={
-            UrlFileName(f): hashlib.sha256(f.read_bytes()).hexdigest() for f in files
+            f: hashlib.sha256(f.read_bytes()).hexdigest() for f in files
         }
     )
 
@@ -47,8 +47,8 @@ def main(files, workspace, backend_token, user, api_server):
 
     try:
         for f in files:
-            release_file = ReleaseFile(name=UrlFileName(f))
-            logger.info(f"  - uploading {f}...")
+            release_file = ReleaseFile(name=f)
+            logger.info(f" - uploading {f}...")
             do_post(release_url, release_file.json(), auth_token)
     except Forbidden:
         # they can create releases, but not upload them

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from publisher import schema
+
+
+def test_release_file():
+    assert schema.ReleaseFile(name=Path("a/b/c")).name == "a/b/c"
+    assert schema.ReleaseFile(name=Path(r"a\b\c")).name == "a/b/c"
+
+
+

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -89,4 +89,5 @@ def test_main_success(workspace_files, urlopen):
     )
 
     for f, r in zip(workspace_files, urlopen.requests[1:]):
-        assert json.loads(r.data) == {"name": str(f)}
+        normalized_path = str(f).replace("\\", "/")
+        assert json.loads(r.data) == {"name": normalized_path}


### PR DESCRIPTION
UrlFileName only does the separator conversion when part of a pydantic
model - my previous attempts to use it directly were just plain wrong.

The correct fix was to specify the name field to be the correct type,
and path separator normalisation works as intended, in that its now
impossible to send \ separated paths as part of the message.
